### PR TITLE
added numpy include directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import os
 from setuptools import setup
 from setuptools.extension import Extension
 from setuptools.command.sdist import sdist as _sdist
+import numpy
 
 cython_locs = [
     ('bandmat', 'full'),
@@ -45,14 +46,14 @@ if dev_mode:
     cmdclass = {'build_ext': build_ext, 'sdist': sdist}
     ext_modules = [
         Extension('.'.join(loc), [os.path.join(*loc)+'.pyx'],
-                  extra_compile_args=['-Wno-unused-but-set-variable', '-O3'])
+                  extra_compile_args=['-Wno-unused-but-set-variable', '-O3'], include_dirs=[numpy.get_include()])
         for loc in cython_locs
     ]
 else:
     cmdclass = {}
     ext_modules = [
         Extension('.'.join(loc), [os.path.join(*loc)+'.c'],
-                  extra_compile_args=['-Wno-unused-but-set-variable', '-O3'])
+                  extra_compile_args=['-Wno-unused-but-set-variable', '-O3'], include_dirs=[numpy.get_include()])
         for loc in cython_locs
     ]
 


### PR DESCRIPTION
Seems to be necessary when compiling on certain systems (tried Windows
Python 2.7 with MSVC; Windows Anaconda Python 2.7 with GCC; ..).
