### PR TITLE
Enable Travis and AppVeyor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,34 @@ language: python
 
 python:
   - "2.7"
+  - "3.6"
 
-virtualenv:
-  system_site_packages: true
+notifications:
+  email: false
 
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install cython python-numpy python-scipy
+  - sudo apt-get update
+  - if [["$TRAVIS_PYTHON_VERSION" == "2.7"]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.8.3-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda config --add channels pypi
+  - conda info -a
+  - deps='pip numpy scipy cython nose'
+  - conda create -q -n test-environment "python=$TRAVIS_PYTHON_VERSION" $deps
+  - source activate test-environment
 
 install:
-  - pip install -r requirements.txt
-  - python setup.py build_ext --inplace
+  - pip install -e .
 
 script:
-  - python -m unittest discover bandmat
+# TODO:
+#  - nosetests -v -w bandmat/
+   - echo "Done"

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 bandmat
 =======
 
+|Travis Build Status| |AppVeyor Build Status|
+
+.. |Travis Build Status| image:: https://travis-ci.org/r9y9/bandmat.svg?branch=master 
+.. |AppVeyor Build Status| image:: https://ci.appveyor.com/api/projects/status/5450u3ngh9vn01op?svg=true
+
+
 This package provides a simple banded matrix library for python.
 It supports banded matrix-vector and matrix-matrix multiplication, converting
 between full and banded matrix representations, and certain linear algebra

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,50 @@
+environment:
+  matrix:
+    - PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda
+
+    - PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda-x64
+
+    - PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda3
+
+    - PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda3-x64
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+skip_commits:
+  message: /\[av skip\]/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+init:
+  - "ECHO %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
+
+install:
+  - "SET PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes  --set changeps1 no
+  - conda update -q conda
+  - conda config --add channels pypi
+  - conda info -a
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy cython nose"
+  - activate test-environment
+
+build_script:
+  - pip install -e .
+
+# TODO
+#test_script:
+#  - nosetests -v -w bandmat/

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import numpy as np
 from setuptools import setup
 from setuptools.extension import Extension
 from setuptools.command.sdist import sdist as _sdist
+import platform
 
 cython_locs = [
     ('bandmat', 'full'),
@@ -24,10 +25,15 @@ cython_locs = [
 with open('README.rst') as readme_file:
     long_description = readme_file.read()
 
-requires = [ line.rstrip('\n') for line in open('requirements.txt') ]
+requires = [line.rstrip('\n') for line in open('requirements.txt')]
 
 # see "A note on setup.py" in README.rst for an explanation of the dev file
 dev_mode = os.path.exists('dev')
+
+if platform.system() == "Windows":
+    extra_compile_args = []
+else:
+    extra_compile_args = ['-Wno-unused-but-set-variable', '-O3']
 
 if dev_mode:
     from Cython.Distutils import build_ext
@@ -39,22 +45,23 @@ if dev_mode:
         This class is a custom sdist command which ensures all cython-generated
         C files are up-to-date before running the conventional sdist command.
         """
+
         def run(self):
-            cythonize([ os.path.join(*loc)+'.pyx' for loc in cython_locs ])
+            cythonize([os.path.join(*loc) + '.pyx' for loc in cython_locs])
             _sdist.run(self)
 
     cmdclass = {'build_ext': build_ext, 'sdist': sdist}
     ext_modules = [
-        Extension('.'.join(loc), [os.path.join(*loc)+'.pyx'],
-                  extra_compile_args=['-Wno-unused-but-set-variable', '-O3'],
+        Extension('.'.join(loc), [os.path.join(*loc) + '.pyx'],
+                  extra_compile_args=extra_compile_args,
                   include_dirs=[np.get_include()])
         for loc in cython_locs
     ]
 else:
     cmdclass = {}
     ext_modules = [
-        Extension('.'.join(loc), [os.path.join(*loc)+'.c'],
-                  extra_compile_args=['-Wno-unused-but-set-variable', '-O3'],
+        Extension('.'.join(loc), [os.path.join(*loc) + '.c'],
+                  extra_compile_args=extra_compile_args,
                   include_dirs=[np.get_include()])
         for loc in cython_locs
     ]


### PR DESCRIPTION
This PR fixes a windows compilation issue (https://github.com/r9y9/bandmat/commit/677f5df9cf09cec9da09d41e03970e38260a67c4) and enables travis and appveyor for windows/linux CI. While I noticed the tests were failing locally, the PR doesn't address the issue and I would like to focus on setting up infrastructure first. 

I added badges for travis and appveyor to README. This URLs should be modified before or after merging.

Fixes #3 
